### PR TITLE
CMake -- Link the final fxite executable against X11

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ TARGET_LINK_LIBRARIES (
     jeffx
     ${LUA_LIBRARIES}
     ${FOX_LDFLAGS}
+    ${X11_X11_LIB}
 )
 
 INSTALL (TARGETS fxite         RUNTIME DESTINATION bin)


### PR DESCRIPTION
Hello,

I suppose this should fix the final link command on Linux. Regarding reswrap, I saw that the helptext.h and help_lua.h files weren't included in the FXITE-0_91 release. What are your plans?

Unfortunately I don't have an easy way to test the CMake build system on Windows.
