### PR TITLE
Fix with fox 1.7.42, where fxsleep() has been replaced by FXThread::slee...

### DIFF
--- a/src/luafuncs.cpp
+++ b/src/luafuncs.cpp
@@ -942,10 +942,10 @@ static int sleep(lua_State*L)
   ms=ms%1000;
   for (int i=0; i<secs; i++) { // Just sleep for one second at a time, to give user a chance to cancel
     if (!breathe(L)) { return 0; }
-    fxsleep(1000000);
+    FXThread::sleep(1000000);
   }
   if (!breathe(L)) { return 0; }
-  fxsleep(ms*1000);
+  FXThread::sleep(ms*1000);
   return 0;
 }
 


### PR DESCRIPTION
I'd also like to ask you to release a new minor version (0.92) so I can keep tracking official releases from the FreeBSD ports. Thanks!
